### PR TITLE
GP-1638: Handle 'is_active' param in 'Engage->getpetitions' api.

### DIFF
--- a/api/v3/Engage/Getpetitions.php
+++ b/api/v3/Engage/Getpetitions.php
@@ -37,6 +37,7 @@ function civicrm_api3_engage_getpetitions($params) {
   $params['campaign_id']       = array('IN' => $active_campaign_ids);
   $params['option.limit']      = 0;
   $params['check_permissions'] = 0;
+  $params['is_active'] = isset($params['is_active']) ? $params['is_active'] : 1;
 
   $petitions = civicrm_api3('Survey', 'get', $params);
 


### PR DESCRIPTION
1. API 'Engage->getpetitions' handles **'is_active'** param;
2. Default value for  **'is_active'** param is '1';