### PR TITLE
GP-983:Update activity with UTM params

### DIFF
--- a/CRM/Gpapi/Processor.php
+++ b/CRM/Gpapi/Processor.php
@@ -364,5 +364,33 @@ class CRM_Gpapi_Processor {
     }
     return $phone;
   }
+
+  /**
+   * Creates Activity with UTM Tracking Parameters
+   *
+   * @param $params
+   * @param $activity_type
+   *
+   * @throws \CiviCRM_API3_Exception
+   */
+  public static function createActivityWithUTM($params, $activity_type) {
+    if (empty($params['utm_source'])
+      && empty($params['utm_medium'])
+      && empty($params['utm_campaign'])
+      && empty($params['utm_content'])
+      || empty($params['contact_id'])) {
+      return;
+    }
+
+    $params['target_id'] = $params['contact_id'];
+    unset($params['contact_id']);
+    $params['activity_type_id'] = $activity_type;
+    $params['subject'] = 'UTM Tracking';
+    $params['status_id'] = 'Scheduled';
+    $params['check_permissions'] = 0;
+
+    CRM_Gpapi_Processor::resolveCustomFields($params, ['utm']);
+    civicrm_api3('Activity', 'create', $params);
+  }
 }
 

--- a/CRM/Gpapi/Processor.php
+++ b/CRM/Gpapi/Processor.php
@@ -366,31 +366,29 @@ class CRM_Gpapi_Processor {
   }
 
   /**
-   * Creates Activity with UTM Tracking Parameters
+   * Updates Activity with UTM Tracking Parameters
    *
    * @param $params
-   * @param $activity_type
+   * @param $activity_id
    *
    * @throws \CiviCRM_API3_Exception
    */
-  public static function createActivityWithUTM($params, $activity_type) {
-    if (empty($params['utm_source'])
-      && empty($params['utm_medium'])
-      && empty($params['utm_campaign'])
-      && empty($params['utm_content'])
-      || empty($params['contact_id'])) {
-      return;
+  public static function updateActivityWithUTM($params, $activity_id) {
+    $activity_params['id'] = $activity_id;
+    $utm_keys = ['utm_source', 'utm_medium', 'utm_campaign', 'utm_content'];
+    $count_of_not_empty_utm_params = 0;
+
+    foreach ($utm_keys as $utm_key) {
+      if (!empty($params[$utm_key])) {
+        $count_of_not_empty_utm_params++;
+        $activity_params[$utm_key] = $params[$utm_key];
+      }
     }
 
-    $params['target_id'] = $params['contact_id'];
-    unset($params['contact_id']);
-    $params['activity_type_id'] = $activity_type;
-    $params['subject'] = 'UTM Tracking';
-    $params['status_id'] = 'Scheduled';
-    $params['check_permissions'] = 0;
-
-    CRM_Gpapi_Processor::resolveCustomFields($params, ['utm']);
-    civicrm_api3('Activity', 'create', $params);
+    if ($count_of_not_empty_utm_params > 0) {
+      CRM_Gpapi_Processor::resolveCustomFields($activity_params, ['utm']);
+      civicrm_api3('Activity', 'create', $activity_params);
+    }
   }
 }
 

--- a/api/v3/Engage/Signpetition.php
+++ b/api/v3/Engage/Signpetition.php
@@ -304,21 +304,21 @@ function _civicrm_api3_engage_signpetition_spec(&$params) {
   $params['utm_source'] = [
     'name' => 'utm_source',
     'title' => 'UTM Source',
-    'api.required' => 1,
+    'api.required' => 0,
   ];
   $params['utm_medium'] = [
     'name' => 'utm_medium',
     'title' => 'UTM Medium',
-    'api.required' => 1,
+    'api.required' => 0,
   ];
   $params['utm_campaign'] = [
     'name' => 'utm_campaign',
     'title' => 'UTM Campaign',
-    'api.required' => 1,
+    'api.required' => 0,
   ];
   $params['utm_content'] = [
     'name' => 'utm_content',
     'title' => 'UTM Content',
-    'api.required' => 1,
+    'api.required' => 0,
   ];
 }

--- a/api/v3/Engage/Signpetition.php
+++ b/api/v3/Engage/Signpetition.php
@@ -168,6 +168,7 @@ function _civicrm_api3_engage_signpetition_process($params) {
       ) + $params); // add other params
     }
 
+    $params['contact_id'] = $contact_id;
     CRM_Gpapi_Processor::createActivityWithUTM($params, 'Petition');
     CRM_Gpapi_Processor::createActivityWithUTM($params, 'Open Case');
 
@@ -297,5 +298,27 @@ function _civicrm_api3_engage_signpetition_spec(&$params) {
     'api.default'  => 'engagement',
     'title'        => 'XCM Profile',
     'description'  => 'XCM profile to be used for contact matching',
+  ];
+
+  // UTM fields:
+  $params['utm_source'] = [
+    'name' => 'utm_source',
+    'title' => 'UTM Source',
+    'api.required' => 1,
+  ];
+  $params['utm_medium'] = [
+    'name' => 'utm_medium',
+    'title' => 'UTM Medium',
+    'api.required' => 1,
+  ];
+  $params['utm_campaign'] = [
+    'name' => 'utm_campaign',
+    'title' => 'UTM Campaign',
+    'api.required' => 1,
+  ];
+  $params['utm_content'] = [
+    'name' => 'utm_content',
+    'title' => 'UTM Content',
+    'api.required' => 1,
   ];
 }

--- a/api/v3/Engage/Signpetition.php
+++ b/api/v3/Engage/Signpetition.php
@@ -168,6 +168,9 @@ function _civicrm_api3_engage_signpetition_process($params) {
       ) + $params); // add other params
     }
 
+    CRM_Gpapi_Processor::createActivityWithUTM($params, 'Petition');
+    CRM_Gpapi_Processor::createActivityWithUTM($params, 'Open Case');
+
     // create result
     if (!empty($params['sequential'])) {
       return civicrm_api3_create_success(array($result));

--- a/api/v3/OSF/Contract.php
+++ b/api/v3/OSF/Contract.php
@@ -343,6 +343,8 @@ function _civicrm_api3_o_s_f_contract_process(&$params) {
       civicrm_api3('Membership', 'create', $membership_data);
     }
 
+    CRM_Gpapi_Processor::createActivityWithUTM($params, 'Contract_Signed');
+
     // and return the good news (otherwise an Exception would have occurred)
     return $result;
   } catch (Exception $e) {

--- a/api/v3/OSF/Contract.php
+++ b/api/v3/OSF/Contract.php
@@ -508,4 +508,26 @@ function _civicrm_api3_o_s_f_contract_spec(&$params) {
     'api.required' => 0,
     'title'        => 'ID of the contact who referred this contract',
   ];
+
+  // UTM fields:
+  $params['utm_source'] = [
+    'name' => 'utm_source',
+    'title' => 'UTM Source',
+    'api.required' => 1,
+  ];
+  $params['utm_medium'] = [
+    'name' => 'utm_medium',
+    'title' => 'UTM Medium',
+    'api.required' => 1,
+  ];
+  $params['utm_campaign'] = [
+    'name' => 'utm_campaign',
+    'title' => 'UTM Campaign',
+    'api.required' => 1,
+  ];
+  $params['utm_content'] = [
+    'name' => 'utm_content',
+    'title' => 'UTM Content',
+    'api.required' => 1,
+  ];
 }

--- a/api/v3/OSF/Contract.php
+++ b/api/v3/OSF/Contract.php
@@ -513,21 +513,21 @@ function _civicrm_api3_o_s_f_contract_spec(&$params) {
   $params['utm_source'] = [
     'name' => 'utm_source',
     'title' => 'UTM Source',
-    'api.required' => 1,
+    'api.required' => 0,
   ];
   $params['utm_medium'] = [
     'name' => 'utm_medium',
     'title' => 'UTM Medium',
-    'api.required' => 1,
+    'api.required' => 0,
   ];
   $params['utm_campaign'] = [
     'name' => 'utm_campaign',
     'title' => 'UTM Campaign',
-    'api.required' => 1,
+    'api.required' => 0,
   ];
   $params['utm_content'] = [
     'name' => 'utm_content',
     'title' => 'UTM Content',
-    'api.required' => 1,
+    'api.required' => 0,
   ];
 }

--- a/api/v3/OSF/Donation.php
+++ b/api/v3/OSF/Donation.php
@@ -201,6 +201,28 @@ function _civicrm_api3_o_s_f_donation_spec(&$params) {
     'api.required' => 0,
     'title'        => 'Transaction ID (only for payment_instrument!=OOFF)',
   ];
+
+  // UTM fields:
+  $params['utm_source'] = [
+    'name' => 'utm_source',
+    'title' => 'UTM Source',
+    'api.required' => 1,
+  ];
+  $params['utm_medium'] = [
+    'name' => 'utm_medium',
+    'title' => 'UTM Medium',
+    'api.required' => 1,
+  ];
+  $params['utm_campaign'] = [
+    'name' => 'utm_campaign',
+    'title' => 'UTM Campaign',
+    'api.required' => 1,
+  ];
+  $params['utm_content'] = [
+    'name' => 'utm_content',
+    'title' => 'UTM Content',
+    'api.required' => 1,
+  ];
 }
 
 

--- a/api/v3/OSF/Donation.php
+++ b/api/v3/OSF/Donation.php
@@ -206,22 +206,22 @@ function _civicrm_api3_o_s_f_donation_spec(&$params) {
   $params['utm_source'] = [
     'name' => 'utm_source',
     'title' => 'UTM Source',
-    'api.required' => 1,
+    'api.required' => 0,
   ];
   $params['utm_medium'] = [
     'name' => 'utm_medium',
     'title' => 'UTM Medium',
-    'api.required' => 1,
+    'api.required' => 0,
   ];
   $params['utm_campaign'] = [
     'name' => 'utm_campaign',
     'title' => 'UTM Campaign',
-    'api.required' => 1,
+    'api.required' => 0,
   ];
   $params['utm_content'] = [
     'name' => 'utm_content',
     'title' => 'UTM Content',
-    'api.required' => 1,
+    'api.required' => 0,
   ];
 }
 

--- a/api/v3/OSF/Donation.php
+++ b/api/v3/OSF/Donation.php
@@ -52,6 +52,7 @@ function _civicrm_api3_o_s_f_donation_process($params) {
     $params['check_permissions'] = 0;
 
     CRM_Gpapi_Processor::resolveCampaign($params);
+    CRM_Gpapi_Processor::createActivityWithUTM($params, 'Contribution');
 
     // format amount
     $params['total_amount'] = number_format($params['total_amount'], 2, '.', '');


### PR DESCRIPTION
Update activity with custom fields in API:
1. 'OSF'->'contract'
2. 'OSF'->'donation',
3. 'Engage'->'signpetition'

Saves UTM params:
1. 'utm_source'
2. 'utm_medium'
3. 'utm_campaign'
4. 'utm_content'
