### PR TITLE
Gp 21465:  Handle new field in 'OSF.order' api and save this data into custom fields. 

### DIFF
--- a/CRM/Gpapi/Processor.php
+++ b/CRM/Gpapi/Processor.php
@@ -625,4 +625,29 @@ class CRM_Gpapi_Processor {
     $contact_data['id'] = min($contacts['values'])['id'];
   }
 
+  /**
+   * @param $countryIsoCode
+   * @return false|int
+   */
+  public static function getCountryIdByIsoCode($countryIsoCode) {
+    if (empty($countryIsoCode)) {
+      return false;
+    }
+
+    try {
+      $country = civicrm_api3('Country', 'getsingle', [
+        'check_permissions' => 0,
+        'iso_code' => $countryIsoCode,
+      ]);
+    } catch (Exception $e) {
+      return false;
+    }
+
+    if (!isset($country['id']) || empty($country['id'])) {
+      return false;
+    }
+
+    return (int) $country['id'];
+  }
+
 }

--- a/CRM/Gpapi/Processor.php
+++ b/CRM/Gpapi/Processor.php
@@ -650,4 +650,71 @@ class CRM_Gpapi_Processor {
     return (int) $country['id'];
   }
 
+  /**
+   * @param $contactId
+   * @return bool
+   */
+  public static function isContactExist($contactId) {
+    if (empty($contactId)) {
+      return false;
+    }
+
+    try {
+      $contact = civicrm_api3('Contact', 'getsingle', [
+        'check_permissions' => 0,
+        'return' => ["id"],
+        'id' => $contactId,
+      ]);
+    } catch (Exception $e) {
+      return false;
+    }
+
+    return isset($contact['id']) && !empty($contact['id']);
+  }
+
+  /**
+   * @param $contactId
+   * @return array
+   */
+  public static function retrieveContactSourceData($contactId) {
+    $contactSourceData = [];
+
+    if (empty($contactId)) {
+      return $contactSourceData;
+    }
+
+    $contactSourceDataFields = [
+      "email",
+      "first_name",
+      "last_name",
+      "gender_id",
+      "phone",
+      "street_address",
+      "postal_code",
+      "city",
+      "country_id",
+    ];
+
+    $apiReturnFields = $contactSourceDataFields;
+    $apiReturnFields[] = 'country';// add 'country' field to get 'country_id' field
+
+    try {
+      $contact = civicrm_api3('Contact', 'getsingle', [
+        'check_permissions' => 0,
+        'id' => $contactId,
+        'return' => $apiReturnFields,
+      ]);
+    } catch (Exception $e) {
+      return $contactSourceData;
+    }
+
+    foreach ($contactSourceDataFields as $field) {
+      if (isset($contact[$field])) {
+        $contactSourceData[$field] = $contact[$field];
+      }
+    }
+
+    return $contactSourceData;
+  }
+
 }

--- a/api/v3/OSF/Order.php
+++ b/api/v3/OSF/Order.php
@@ -91,65 +91,65 @@ function _civicrm_api3_o_s_f_order_process($params) {
  */
 function _civicrm_api3_o_s_f_order_spec(&$params) {
   // CONTACT BASE
-  $params['contact_id'] = array(
+  $params['contact_id'] = [
     'name'         => 'contact_id',
     'api.required' => 1,
     'title'        => 'CiviCRM Contact ID',
-    );
-  $params['campaign'] = array(
+  ];
+  $params['campaign'] = [
     'name'         => 'campaign',
     'api.required' => 0,
     'title'        => 'CiviCRM Campaign (external identifier)',
-    );
-  $params['campaign_id'] = array(
+  ];
+  $params['campaign_id'] = [
     'name'         => 'campaign_id',
     'api.required' => 0,
     'title'        => 'CiviCRM Campaign ID',
     'description'  => 'Overwrites "campaign"',
-    );
-  $params['subject'] = array(
+  ];
+  $params['subject'] = [
     'name'         => 'subject',
     'api.default'  => "Webshop Order",
     'title'        => 'Webshop Order Subject Line. DEPRECATED',
-    );
-  $params['order_type'] = array(
+  ];
+  $params['order_type'] = [
     'name'         => 'order_type',
     'api.required' => 1,
     'title'        => 'Webshop Order Type',
-    );
-  $params['shirt_type'] = array(
+  ];
+  $params['shirt_type'] = [
     'name'         => 'shirt_type',
     'api.required' => 0,
     'title'        => 'T-Shirt Type: M/W',
-    );
-  $params['shirt_size'] = array(
+  ];
+  $params['shirt_size'] = [
     'name'         => 'shirt_size',
     'api.required' => 0,
     'title'        => 'T-Shirt Size: S/M/L/XL',
-    );
-  $params['order_count'] = array(
+  ];
+  $params['order_count'] = [
     'name'         => 'order_count',
     'api.required' => 1,
     'title'        => 'Webshop Order Count',
-    );
-  $params['linked_contribution'] = array(
+  ];
+  $params['linked_contribution'] = [
     'name'         => 'linked_contribution',
     'api.required' => 0,
     'title'        => 'Linked Contribution ID',
-    );
-  $params['linked_membership'] = array(
+  ];
+  $params['linked_membership'] = [
     'name'         => 'linked_membership',
     'api.required' => 0,
     'title'        => 'Linked Membership ID',
-    );
-  $params['payment_received'] = array(
+  ];
+  $params['payment_received'] = [
     'name'         => 'payment_received',
     'api.required' => 1,
     'title'        => 'Webshop Order Payment Received',
-    );
-  $params['multi_purpose'] = array(
+  ];
+  $params['multi_purpose'] = [
     'name'         => 'multi_purpose',
     'api.required' => 0,
     'title'        => 'Webshop Order CustomData',
-    );
+  ];
 }

--- a/api/v3/OSF/Order.php
+++ b/api/v3/OSF/Order.php
@@ -72,8 +72,15 @@ function _civicrm_api3_o_s_f_order_process($params) {
     $params['status_id']         = 'Scheduled';
     $params['check_permissions'] = 0;
 
+    if (isset($params['country_iso_code']) && !empty($params['country_iso_code'])) {
+      $countryId = CRM_Gpapi_Processor::getCountryIdByIsoCode($params['country_iso_code']);
+      if (!empty($countryId)) {
+        $params['country_id'] = $countryId;
+      }
+    }
+
     // resolve custom fields
-    CRM_Gpapi_Processor::resolveCustomFields($params, array('webshop_information'));
+    CRM_Gpapi_Processor::resolveCustomFields($params, ['webshop_information', 'source_contact_data']);
 
     // create Webshop Order activity
     return civicrm_api3('Activity', 'create', $params);
@@ -151,5 +158,68 @@ function _civicrm_api3_o_s_f_order_spec(&$params) {
     'name'         => 'multi_purpose',
     'api.required' => 0,
     'title'        => 'Webshop Order CustomData',
+  ];
+  $params['first_name'] = [
+    'name'         => 'first_name',
+    'api.required' => 0,
+    'title'        => 'First name',
+    'description'  => '(Source contact)',
+    'type'         => CRM_Utils_TYPE::T_STRING,
+  ];
+  $params['last_name'] = [
+    'name'         => 'last_name',
+    'api.required' => 0,
+    'title'        => 'Last name',
+    'description'  => '(Source contact)',
+    'type'         => CRM_Utils_TYPE::T_STRING,
+  ];
+  $params['gender_id'] = [
+    'name'         => 'gender_id',
+    'api.required' => 0,
+    'title'        => 'Gender',
+    'description'  => '(Source contact)',
+    'type'         => CRM_Utils_TYPE::T_STRING,
+  ];
+  $params['email'] = [
+    'name'         => 'email',
+    'api.required' => 0,
+    'title'        => 'Email',
+    'description'  => '(Source contact)',
+    'type'         => CRM_Utils_TYPE::T_STRING,
+  ];
+  $params['phone'] = [
+    'name'         => 'phone',
+    'api.required' => 0,
+    'title'        => 'Phone',
+    'description'  => '(Source contact)',
+    'type'         => CRM_Utils_TYPE::T_STRING,
+  ];
+  $params['street_address'] = [
+    'name'         => 'street_address',
+    'api.required' => 0,
+    'title'        => 'Street address',
+    'description'  => '(Source contact)',
+    'type'         => CRM_Utils_TYPE::T_STRING,
+  ];
+  $params['postal_code'] = [
+    'name'         => 'postal_code',
+    'api.required' => 0,
+    'title'        => 'Postal code',
+    'description'  => '(Source contact)',
+    'type'         => CRM_Utils_TYPE::T_STRING,
+  ];
+  $params['city'] = [
+    'name'         => 'city',
+    'api.required' => 0,
+    'title'        => 'City',
+    'description'  => '(Source contact)',
+    'type'         => CRM_Utils_TYPE::T_STRING,
+  ];
+  $params['country_iso_code'] = [
+    'name'         => 'country_iso_code',
+    'api.required' => 0,
+    'title'        => 'Country iso code',
+    'description'  => '(Source contact)',
+    'type'         => CRM_Utils_TYPE::T_STRING,
   ];
 }


### PR DESCRIPTION
1. `OSF.order` api  handles new field:
    - civi_referrer_contact_id
    - first_name
    - last_name
    - gender_id
    - email
    - phone
    - street_address
    - postal_code
    - city
    - country_iso_code
2. `OSF.order` api  saves those fields to `source_contact_data`.
3.  If `civi_referrer_contact_id` filed exist then retrieve contact data by `contact id(civi_referrer_contact_id)` and then save this data into `source_contact_data`. 
4. To use this functionality do not forgot to apply pull request: https://github.com/greenpeace-cee/civiconfig/pull/32
