### PR TITLE
GP-31041 Newsletter Subscribe Xcm Profile default engagement

### DIFF
--- a/api/v3/Newsletter/Subscribe.php
+++ b/api/v3/Newsletter/Subscribe.php
@@ -218,4 +218,12 @@ function _civicrm_api3_newsletter_subscribe_spec(&$params) {
     'api.required' => 0,
     'title'        => 'Country',
     );
+
+  $params['xcm_profile'] = [
+    'name'         => 'xcm_profile',
+    'api.required' => 0,
+    'api.default'  => 'engagement',
+    'title'        => 'XCM Profile',
+    'description'  => 'XCM profile to be used for contact matching',
+  ];
 }


### PR DESCRIPTION
Added xcm_profile=engagement as a default parameter to Newsletter.subscribe API (matching e.g. Engage.signpetition)