### PR TITLE
GP-44499 Fix invoice_id not being set to trxn_id as fallback

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -73,13 +73,13 @@ jobs:
           PATH="/home/runner/buildkit/bin:$PATH"
           cd "$EXT_DIR"
           cp -R "$GITHUB_WORKSPACE/at.greenpeace.gpapi" "$EXT_DIR/at.greenpeace.gpapi"
-          git clone https://github.com/systopia/de.systopia.xcm.git
+          git clone https://github.com/greenpeace-cee/de.systopia.xcm.git
           git clone https://github.com/greenpeace-cee/com.cividesk.normalize.git
-          git clone https://github.com/Project60/org.project60.sepa.git
+          git clone https://github.com/greenpeace-cee/org.project60.sepa.git
           git clone https://github.com/systopia/de.systopia.pspsepa.git
           git clone https://github.com/Project60/org.project60.banking.git
           git clone https://github.com/greenpeace-cee/de.systopia.contract.git
-          git clone https://lab.civicrm.org/extensions/mjwshared.git -b 1.2.22
+          git clone https://github.com/greenpeace-cee/mjwshared.git
           git clone https://github.com/greenpeace-cee/adyen.git -b main
           git clone https://github.com/greenpeace-cee/de.systopia.identitytracker.git
           cv en adyen at.greenpeace.gpapi

--- a/api/v3/OSF/Donation.php
+++ b/api/v3/OSF/Donation.php
@@ -325,8 +325,8 @@ function _civicrm_api3_o_s_f_donation_create_nonsepa_contribution($params, $paym
   }
 
   $psp_result_data = $params['psp_result_data'] ?? [];
-  $params['trxn_id'] = $psp_result_data['pspReference'] ?? $params['trxn_id'];
-  $params['invoice_id'] = $psp_result_data['merchantReference'] ?? NULL;
+  $params['trxn_id'] = $psp_result_data['pspReference'] ?? NULL;
+  $params['invoice_id'] = $psp_result_data['merchantReference'] ?? $params['trxn_id'];
 
   $order = civicrm_api3('Order', 'create', [
     'campaign_id'           => CRM_Utils_Array::value('campaign_id', $params),

--- a/managed/PetitionInformation.mgd.php
+++ b/managed/PetitionInformation.mgd.php
@@ -1,0 +1,74 @@
+<?php
+
+use CRM_Gpapi_ExtensionUtil as E;
+
+return [
+  [
+    'name' => 'CustomGroup_petition_information',
+    'entity' => 'CustomGroup',
+    'cleanup' => 'never',
+    'update' => 'always',
+    'params' => [
+      'version' => 4,
+      'values' => [
+        'name' => 'petition_information',
+        'title' => E::ts('Petition Information'),
+        'extends' => 'Activity',
+        'extends_entity_column_value:name' => [
+          'Petition',
+        ],
+        'style' => 'Inline',
+        'help_pre' => '',
+        'help_post' => '',
+        'weight' => 34,
+        'collapse_adv_display' => TRUE,
+      ],
+      'match' => [
+        'name',
+      ],
+    ],
+  ],
+  [
+    'name' => 'CustomGroup_petition_information_CustomField_petition_dialoger',
+    'entity' => 'CustomField',
+    'cleanup' => 'never',
+    'update' => 'always',
+    'params' => [
+      'version' => 4,
+      'values' => [
+        'custom_group_id.name' => 'petition_information',
+        'name' => 'petition_dialoger',
+        'label' => E::ts('Dialoger'),
+        'data_type' => 'ContactReference',
+        'html_type' => 'Autocomplete-Select',
+        'is_searchable' => TRUE,
+        'column_name' => 'petition_dialoger',
+        'filter' => 'action=lookup&group=',
+      ],
+      'match' => [
+        'name',
+      ],
+    ],
+  ],
+  [
+    'name' => 'CustomGroup_petition_information_CustomField_external_identifier',
+    'entity' => 'CustomField',
+    'cleanup' => 'never',
+    'update' => 'always',
+    'params' => [
+      'version' => 4,
+      'values' => [
+        'custom_group_id.name' => 'petition_information',
+        'name' => 'external_identifier',
+        'label' => E::ts('External Identifier'),
+        'html_type' => 'Text',
+        'is_searchable' => TRUE,
+        'text_length' => 256,
+        'column_name' => 'external_identifier',
+      ],
+      'match' => [
+        'name',
+      ],
+    ],
+  ],
+];

--- a/managed/SourceContactData.mgd.php
+++ b/managed/SourceContactData.mgd.php
@@ -1,0 +1,335 @@
+<?php
+
+use CRM_Gpapi_ExtensionUtil as E;
+
+return [
+  [
+    'name' => 'CustomGroup_source_contact_data',
+    'entity' => 'CustomGroup',
+    'cleanup' => 'never',
+    'update' => 'always',
+    'params' => [
+      'version' => 4,
+      'values' => [
+        'name' => 'source_contact_data',
+        'title' => E::ts('Source Contact Data'),
+        'extends' => 'Activity',
+        'extends_entity_column_value:name' => [
+          'Open Case',
+          'Petition',
+          'Webshop Order',
+          'Ratgeber verschickt',
+          'anonymisation_request',
+        ],
+        'style' => 'Inline',
+        'help_pre' => '',
+        'help_post' => '',
+        'weight' => 21,
+        'collapse_adv_display' => TRUE,
+      ],
+      'match' => [
+        'name',
+      ],
+    ],
+  ],
+  [
+    'name' => 'CustomGroup_source_contact_data_CustomField_prefix_id',
+    'entity' => 'CustomField',
+    'cleanup' => 'never',
+    'update' => 'always',
+    'params' => [
+      'version' => 4,
+      'values' => [
+        'custom_group_id.name' => 'source_contact_data',
+        'name' => 'prefix_id',
+        'label' => E::ts('Prefix'),
+        'data_type' => 'Int',
+        'html_type' => 'Select',
+        'is_searchable' => TRUE,
+        'column_name' => 'prefix_id',
+        'option_group_id.name' => 'individual_prefix',
+      ],
+      'match' => [
+        'name',
+      ],
+    ],
+  ],
+  [
+    'name' => 'CustomGroup_source_contact_data_CustomField_gender_id',
+    'entity' => 'CustomField',
+    'cleanup' => 'never',
+    'update' => 'always',
+    'params' => [
+      'version' => 4,
+      'values' => [
+        'custom_group_id.name' => 'source_contact_data',
+        'name' => 'gender_id',
+        'label' => E::ts('Gender'),
+        'data_type' => 'Int',
+        'html_type' => 'Select',
+        'is_searchable' => TRUE,
+        'column_name' => 'gender_id',
+        'option_group_id.name' => 'gender',
+      ],
+      'match' => [
+        'name',
+      ],
+    ],
+  ],
+  [
+    'name' => 'CustomGroup_source_contact_data_CustomField_first_name',
+    'entity' => 'CustomField',
+    'cleanup' => 'never',
+    'update' => 'always',
+    'params' => [
+      'version' => 4,
+      'values' => [
+        'custom_group_id.name' => 'source_contact_data',
+        'name' => 'first_name',
+        'label' => E::ts('First Name'),
+        'html_type' => 'Text',
+        'is_searchable' => TRUE,
+        'text_length' => 64,
+        'column_name' => 'first_name',
+      ],
+      'match' => [
+        'name',
+      ],
+    ],
+  ],
+  [
+    'name' => 'CustomGroup_source_contact_data_CustomField_last_name',
+    'entity' => 'CustomField',
+    'cleanup' => 'never',
+    'update' => 'always',
+    'params' => [
+      'version' => 4,
+      'values' => [
+        'custom_group_id.name' => 'source_contact_data',
+        'name' => 'last_name',
+        'label' => E::ts('Last Name'),
+        'html_type' => 'Text',
+        'is_searchable' => TRUE,
+        'text_length' => 64,
+        'column_name' => 'last_name',
+      ],
+      'match' => [
+        'name',
+      ],
+    ],
+  ],
+  [
+    'name' => 'CustomGroup_source_contact_data_CustomField_birth_date',
+    'entity' => 'CustomField',
+    'cleanup' => 'never',
+    'update' => 'always',
+    'params' => [
+      'version' => 4,
+      'values' => [
+        'custom_group_id.name' => 'source_contact_data',
+        'name' => 'birth_date',
+        'label' => E::ts('Birth Date'),
+        'data_type' => 'Date',
+        'html_type' => 'Select Date',
+        'is_searchable' => TRUE,
+        'start_date_years' => 100,
+        'end_date_years' => 0,
+        'date_format' => 'dd.mm.yy',
+        'column_name' => 'birth_date',
+      ],
+      'match' => [
+        'name',
+      ],
+    ],
+  ],
+  [
+    'name' => 'CustomGroup_source_contact_data_CustomField_bpk',
+    'entity' => 'CustomField',
+    'cleanup' => 'never',
+    'update' => 'always',
+    'params' => [
+      'version' => 4,
+      'values' => [
+        'custom_group_id.name' => 'source_contact_data',
+        'name' => 'bpk',
+        'label' => E::ts('bpk'),
+        'html_type' => 'Text',
+        'is_searchable' => TRUE,
+        'text_length' => 28,
+        'column_name' => 'bpk',
+      ],
+      'match' => [
+        'name',
+      ],
+    ],
+  ],
+  [
+    'name' => 'CustomGroup_source_contact_data_CustomField_email',
+    'entity' => 'CustomField',
+    'cleanup' => 'never',
+    'update' => 'always',
+    'params' => [
+      'version' => 4,
+      'values' => [
+        'custom_group_id.name' => 'source_contact_data',
+        'name' => 'email',
+        'label' => E::ts('Email'),
+        'html_type' => 'Text',
+        'is_searchable' => TRUE,
+        'text_length' => 255,
+        'column_name' => 'email',
+      ],
+      'match' => [
+        'name',
+      ],
+    ],
+  ],
+  [
+    'name' => 'CustomGroup_source_contact_data_CustomField_phone',
+    'entity' => 'CustomField',
+    'cleanup' => 'never',
+    'update' => 'always',
+    'params' => [
+      'version' => 4,
+      'values' => [
+        'custom_group_id.name' => 'source_contact_data',
+        'name' => 'phone',
+        'label' => E::ts('Phone'),
+        'html_type' => 'Text',
+        'is_searchable' => TRUE,
+        'text_length' => 32,
+        'column_name' => 'phone',
+      ],
+      'match' => [
+        'name',
+      ],
+    ],
+  ],
+  [
+    'name' => 'CustomGroup_source_contact_data_CustomField_country_id',
+    'entity' => 'CustomField',
+    'cleanup' => 'never',
+    'update' => 'always',
+    'params' => [
+      'version' => 4,
+      'values' => [
+        'custom_group_id.name' => 'source_contact_data',
+        'name' => 'country_id',
+        'label' => E::ts('Country'),
+        'data_type' => 'Country',
+        'html_type' => 'Select',
+        'is_searchable' => TRUE,
+        'column_name' => 'country_id',
+      ],
+      'match' => [
+        'name',
+      ],
+    ],
+  ],
+  [
+    'name' => 'CustomGroup_source_contact_data_CustomField_postal_code',
+    'entity' => 'CustomField',
+    'cleanup' => 'never',
+    'update' => 'always',
+    'params' => [
+      'version' => 4,
+      'values' => [
+        'custom_group_id.name' => 'source_contact_data',
+        'name' => 'postal_code',
+        'label' => E::ts('Postal Code'),
+        'html_type' => 'Text',
+        'is_searchable' => TRUE,
+        'text_length' => 64,
+        'column_name' => 'postal_code',
+      ],
+      'match' => [
+        'name',
+      ],
+    ],
+  ],
+  [
+    'name' => 'CustomGroup_source_contact_data_CustomField_city',
+    'entity' => 'CustomField',
+    'cleanup' => 'never',
+    'update' => 'always',
+    'params' => [
+      'version' => 4,
+      'values' => [
+        'custom_group_id.name' => 'source_contact_data',
+        'name' => 'city',
+        'label' => E::ts('City'),
+        'html_type' => 'Text',
+        'is_searchable' => TRUE,
+        'text_length' => 64,
+        'column_name' => 'city',
+      ],
+      'match' => [
+        'name',
+      ],
+    ],
+  ],
+  [
+    'name' => 'CustomGroup_source_contact_data_CustomField_street_address',
+    'entity' => 'CustomField',
+    'cleanup' => 'never',
+    'update' => 'always',
+    'params' => [
+      'version' => 4,
+      'values' => [
+        'custom_group_id.name' => 'source_contact_data',
+        'name' => 'street_address',
+        'label' => E::ts('Street Address'),
+        'html_type' => 'Text',
+        'is_searchable' => TRUE,
+        'text_length' => 94,
+        'column_name' => 'street_address',
+      ],
+      'match' => [
+        'name',
+      ],
+    ],
+  ],
+  [
+    'name' => 'CustomGroup_source_contact_data_CustomField_newsletter',
+    'entity' => 'CustomField',
+    'cleanup' => 'never',
+    'update' => 'always',
+    'params' => [
+      'version' => 4,
+      'values' => [
+        'custom_group_id.name' => 'source_contact_data',
+        'name' => 'newsletter',
+        'label' => E::ts('Newsletter Opt-In'),
+        'data_type' => 'Boolean',
+        'html_type' => 'Radio',
+        'default_value' => '0',
+        'is_searchable' => TRUE,
+        'column_name' => 'newsletter',
+      ],
+      'match' => [
+        'name',
+      ],
+    ],
+  ],
+  [
+    'name' => 'CustomGroup_source_contact_data_CustomField_geoip_country_id',
+    'entity' => 'CustomField',
+    'cleanup' => 'never',
+    'update' => 'always',
+    'params' => [
+      'version' => 4,
+      'values' => [
+        'custom_group_id.name' => 'source_contact_data',
+        'name' => 'geoip_country_id',
+        'label' => E::ts('GeoIP Country'),
+        'data_type' => 'Country',
+        'html_type' => 'Select',
+        'is_searchable' => TRUE,
+        'column_name' => 'geoip_country_id',
+      ],
+      'match' => [
+        'name',
+      ],
+    ],
+  ],
+];

--- a/managed/UtmTrackingInformation.mgd.php
+++ b/managed/UtmTrackingInformation.mgd.php
@@ -1,0 +1,200 @@
+<?php
+
+use CRM_Gpapi_ExtensionUtil as E;
+
+return [
+  [
+    'name' => 'OptionValue_UTM_Tracking',
+    'entity' => 'OptionValue',
+    'cleanup' => 'never',
+    'update' => 'always',
+    'params' => [
+      'version' => 4,
+      'values' => [
+        'option_group_id.name' => 'activity_type',
+        'label' => E::ts('UTM Tracking'),
+        'name' => 'UTM Tracking',
+      ],
+      'match' => [
+        'option_group_id',
+        'name',
+      ],
+    ],
+  ],
+  [
+    'name' => 'OptionValue_Ratgeber_verschickt',
+    'entity' => 'OptionValue',
+    'cleanup' => 'never',
+    'update' => 'always',
+    'params' => [
+      'version' => 4,
+      'values' => [
+        'option_group_id.name' => 'activity_type',
+        'label' => E::ts('Ratgeber verschickt'),
+        'name' => 'Ratgeber verschickt',
+      ],
+      'match' => [
+        'option_group_id',
+        'name',
+      ],
+    ],
+  ],
+  [
+    'name' => 'CustomGroup_utm',
+    'entity' => 'CustomGroup',
+    'cleanup' => 'never',
+    'update' => 'always',
+    'params' => [
+      'version' => 4,
+      'values' => [
+        'name' => 'utm',
+        'title' => E::ts('UTM Tracking Information'),
+        'extends' => 'Activity',
+        'extends_entity_column_value:name' => [
+          'Contribution',
+          'Open Case',
+          'Petition',
+          'Contract_Signed',
+          'Ratgeber verschickt',
+          'UTM Tracking',
+        ],
+        'style' => 'Inline',
+        'collapse_display' => TRUE,
+        'help_pre' => '',
+        'help_post' => '',
+        'weight' => 12,
+        'collapse_adv_display' => TRUE,
+        'icon' => '',
+      ],
+      'match' => [
+        'name',
+      ],
+    ],
+  ],
+  [
+    'name' => 'CustomGroup_utm_CustomField_utm_source',
+    'entity' => 'CustomField',
+    'cleanup' => 'never',
+    'update' => 'always',
+    'params' => [
+      'version' => 4,
+      'values' => [
+        'custom_group_id.name' => 'utm',
+        'name' => 'utm_source',
+        'label' => E::ts('Source'),
+        'html_type' => 'Text',
+        'is_searchable' => TRUE,
+        'text_length' => 255,
+        'column_name' => 'utm_source',
+      ],
+      'match' => [
+        'name',
+      ],
+    ],
+  ],
+  [
+    'name' => 'CustomGroup_utm_CustomField_utm_medium',
+    'entity' => 'CustomField',
+    'cleanup' => 'never',
+    'update' => 'always',
+    'params' => [
+      'version' => 4,
+      'values' => [
+        'custom_group_id.name' => 'utm',
+        'name' => 'utm_medium',
+        'label' => E::ts('Medium'),
+        'html_type' => 'Text',
+        'is_searchable' => TRUE,
+        'text_length' => 255,
+        'column_name' => 'utm_medium',
+      ],
+      'match' => [
+        'name',
+      ],
+    ],
+  ],
+  [
+    'name' => 'CustomGroup_utm_CustomField_utm_campaign',
+    'entity' => 'CustomField',
+    'cleanup' => 'never',
+    'update' => 'always',
+    'params' => [
+      'version' => 4,
+      'values' => [
+        'custom_group_id.name' => 'utm',
+        'name' => 'utm_campaign',
+        'label' => E::ts('Campaign'),
+        'html_type' => 'Text',
+        'is_searchable' => TRUE,
+        'text_length' => 255,
+        'column_name' => 'utm_campaign',
+      ],
+      'match' => [
+        'name',
+      ],
+    ],
+  ],
+  [
+    'name' => 'CustomGroup_utm_CustomField_utm_content',
+    'entity' => 'CustomField',
+    'cleanup' => 'never',
+    'update' => 'always',
+    'params' => [
+      'version' => 4,
+      'values' => [
+        'custom_group_id.name' => 'utm',
+        'name' => 'utm_content',
+        'label' => E::ts('Content'),
+        'html_type' => 'Text',
+        'is_searchable' => TRUE,
+        'text_length' => 255,
+        'column_name' => 'utm_content',
+      ],
+      'match' => [
+        'name',
+      ],
+    ],
+  ],
+  [
+    'name' => 'CustomGroup_utm_CustomField_utm_term',
+    'entity' => 'CustomField',
+    'cleanup' => 'never',
+    'update' => 'always',
+    'params' => [
+      'version' => 4,
+      'values' => [
+        'custom_group_id.name' => 'utm',
+        'name' => 'utm_term',
+        'label' => E::ts('Term'),
+        'html_type' => 'Text',
+        'is_searchable' => TRUE,
+        'text_length' => 255,
+        'column_name' => 'utm_term',
+      ],
+      'match' => [
+        'name',
+      ],
+    ],
+  ],
+  [
+    'name' => 'CustomGroup_utm_CustomField_utm_id',
+    'entity' => 'CustomField',
+    'cleanup' => 'never',
+    'update' => 'always',
+    'params' => [
+      'version' => 4,
+      'values' => [
+        'custom_group_id.name' => 'utm',
+        'name' => 'utm_id',
+        'label' => E::ts('Id'),
+        'html_type' => 'Text',
+        'is_searchable' => TRUE,
+        'text_length' => 255,
+        'column_name' => 'utm_id',
+      ],
+      'match' => [
+        'name',
+      ],
+    ],
+  ],
+];

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,15 +1,15 @@
 <?xml version="1.0"?>
-<phpunit backupGlobals="false" backupStaticAttributes="false" colors="true" convertErrorsToExceptions="true" convertNoticesToExceptions="true" convertWarningsToExceptions="true" processIsolation="false" stopOnFailure="false" bootstrap="tests/phpunit/bootstrap.php">
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" backupGlobals="false" backupStaticAttributes="false" colors="true" convertErrorsToExceptions="true" convertNoticesToExceptions="true" convertWarningsToExceptions="true" processIsolation="false" stopOnFailure="false" bootstrap="tests/phpunit/bootstrap.php" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
+  <coverage>
+    <include>
+      <directory suffix=".php">./</directory>
+    </include>
+  </coverage>
   <testsuites>
     <testsuite name="My Test Suite">
       <directory>./tests/phpunit</directory>
     </testsuite>
   </testsuites>
-  <filter>
-    <whitelist>
-      <directory suffix=".php">./</directory>
-    </whitelist>
-  </filter>
   <listeners>
     <listener class="Civi\Test\CiviTestListener">
       <arguments/>

--- a/tests/phpunit/api/v3/Engage/EngageTestBase.php
+++ b/tests/phpunit/api/v3/Engage/EngageTestBase.php
@@ -27,7 +27,7 @@ class api_v3_Engage_EngageTestBase
       ->install('org.project60.banking')
       ->install('de.systopia.contract')
       ->install('de.systopia.xcm')
-      ->apply(TRUE);
+      ->apply();
   }
 
   public function setUp(): void {
@@ -45,7 +45,7 @@ class api_v3_Engage_EngageTestBase
     Civi::settings()->set('enable_components', $enCompSetting);
 
     self::createRequiredOptionValues();
-    self::createRequiredCustomGroups();
+    self::fixOptionValues();
     self::createRequiredGroups();
     self::createRequiredProfiles();
     $this->caseType = self::defineCaseType();
@@ -72,144 +72,12 @@ class api_v3_Engage_EngageTestBase
     ]);
   }
 
-  private static function createRequiredCustomGroups() {
-    civicrm_api3('CustomGroup', 'create', [
-      'name'       => 'petition_information',
-      'title'      => 'Petition Information',
-      'table_name' => 'civicrm_value_petition_information',
-      'extends'    => 'Activity',
-      'extends_entity_column_value' => [
-        self::getOptionValue('activity_type', 'Petition'),
-      ],
-    ]);
-
-    civicrm_api3('CustomGroup', 'create', [
-      'name'       => 'source_contact_data',
-      'title'      => 'Source Contact Data',
-      'table_name' => 'civicrm_value_source_contact_data',
-      'extends'    => 'Activity',
-      'extends_entity_column_value' => [
-        self::getOptionValue('activity_type', 'anonymisation_request'),
-        self::getOptionValue('activity_type', 'Open Case'),
-        self::getOptionValue('activity_type', 'Petition'),
-        self::getOptionValue('activity_type', 'Ratgeber verschickt'),
-      ],
-    ]);
-
-    $sourceContactDataFields = [
-      [
-        'name'      => 'prefix_id',
-        'label'     => 'Prefix',
-        'data_type' => 'Integer',
-      ],
-      [
-        'name'      => 'gender_id',
-        'label'     => 'Gender',
-        'data_type' => 'Integer',
-      ],
-      [
-        'name'      => 'first_name',
-        'label'     => 'First Name',
-        'data_type' => 'String',
-      ],
-      [
-        'name'      => 'last_name',
-        'label'     => 'Last Name',
-        'data_type' => 'String',
-      ],
-      [
-        'name'      => 'birth_date',
-        'label'     => 'Birth Date',
-        'data_type' => 'String',
-      ],
-      [
-        'name'      => 'bpk',
-        'label'     => 'bpk',
-        'data_type' => 'String',
-      ],
-      [
-        'name'      => 'email',
-        'label'     => 'Email',
-        'data_type' => 'String',
-      ],
-      [
-        'name'      => 'phone',
-        'label'     => 'Phone',
-        'data_type' => 'String',
-      ],
-      [
-        'name'      => 'country_id',
-        'label'     => 'Country',
-        'data_type' => 'Country',
-      ],
-      [
-        'name'      => 'postal_code',
-        'label'     => 'Postal Code',
-        'data_type' => 'String',
-      ],
-      [
-        'name'      => 'city',
-        'label'     => 'City',
-        'data_type' => 'String',
-      ],
-      [
-        'name'      => 'street_address',
-        'label'     => 'Street Address',
-        'data_type' => 'String',
-      ],
-      [
-        'name'      => 'newsletter',
-        'label'     => 'Newsletter Opt-In',
-        'data_type' => 'Boolean',
-      ],
-      [
-        'name'      => 'geoip_country_id',
-        'label'     => 'GeoIP County',
-        'data_type' => 'Country',
-      ],
-    ];
-
-    foreach ($sourceContactDataFields as $fieldData) {
-      $fieldData['custom_group_id'] = 'source_contact_data';
-      $fieldData['column_name'] = $fieldData['name'];
-      $fieldData['is_required'] = 0;
-
-      civicrm_api3('CustomField', 'create', $fieldData);
-    }
-
+  private static function fixOptionValues() {
     civicrm_api3('OptionValue', 'create', [
         'id'     => self::getOptionValueID('activity_type', 'Contribution'),
         'filter' => 0,
     ]);
 
-    civicrm_api3('CustomGroup', 'create', [
-      'name'       => 'utm',
-      'title'      => 'UTM Tracking Information',
-      'table_name' => 'civicrm_value_utm',
-      'extends'    => 'Activity',
-      'extends_entity_column_value' => [
-        self::getOptionValue('activity_type', 'Contract_Signed'),
-        self::getOptionValue('activity_type', 'Contribution'),
-        self::getOptionValue('activity_type', 'Petition'),
-        self::getOptionValue('activity_type', 'Open Case'),
-        self::getOptionValue('activity_type', 'Ratgeber verschickt'),
-        self::getOptionValue('activity_type', 'UTM Tracking'),
-      ],
-    ]);
-
-    $utmFieldNames = ['utm_campaign', 'utm_content', 'utm_medium', 'utm_source', 'utm_id', 'utm_term'];
-
-    foreach ($utmFieldNames as $name) {
-      civicrm_api3('CustomField', 'create', [
-        'custom_group_id' => 'utm',
-        'name'            => $name,
-        'label'           => ucfirst(substr($name, 4)),
-        'column_name'     => $name,
-        'data_type'       => 'String',
-        'text_length'     => 255,
-        'is_required'     => 0,
-      ]);
-    }
   }
 
   private static function createRequiredGroups() {
@@ -227,18 +95,8 @@ class api_v3_Engage_EngageTestBase
       ],
       [
         'option_group_id' => 'activity_type',
-        'name'            => 'Ratgeber verschickt',
-        'label'           => 'Ratgeber verschickt',
-      ],
-      [
-        'option_group_id' => 'activity_type',
         'name'            => 'streetimport_error',
         'label'           => 'Import Error',
-      ],
-      [
-        'option_group_id' => 'activity_type',
-        'name'            => 'UTM Tracking',
-        'label'           => 'UTM Tracking',
       ],
       [
         'option_group_id' => 'case_status',

--- a/tests/phpunit/api/v3/OSF/ContractTestBase.php
+++ b/tests/phpunit/api/v3/OSF/ContractTestBase.php
@@ -42,10 +42,6 @@ implements HeadlessInterface, HookInterface, TransactionalInterface {
 
     self::createRequiredOptionValues();
     self::createMembershipTypes();
-    self::createUTMCustomFields();
-    self::createReferralInfoCustomFields();
-    self::createReferrerOfRelationship();
-
     $this->createAdyenPaymentProcessor();
     $this->createDefaultCampaign();
     $this->createDefaultContact();
@@ -62,7 +58,6 @@ implements HeadlessInterface, HookInterface, TransactionalInterface {
     CRM_Gpapi_Identitytracker_Configuration::resetInstance();
 
     set_error_handler($this->defaultErrorHandler, E_USER_DEPRECATED);
-
     parent::tearDown();
   }
 
@@ -184,111 +179,12 @@ implements HeadlessInterface, HookInterface, TransactionalInterface {
       ->execute();
   }
 
-  private static function createReferralInfoCustomFields() {
-    Api4\CustomGroup::create(FALSE)
-      ->addValue('extends'   , 'Membership')
-      ->addValue('name'      , 'membership_referral')
-      ->addValue('table_name', 'civicrm_value_membership_referral')
-      ->addValue('title'     , 'Referral Information')
-      ->execute();
-
-    Api4\CustomField::create(FALSE)
-      ->addValue('column_name'         , 'membership_referrer')
-      ->addValue('custom_group_id:name', 'membership_referral')
-      ->addValue('data_type'           , 'ContactReference')
-      ->addValue('html_type'           , 'Autocomplete-Select')
-      ->addValue('is_required'         , FALSE)
-      ->addValue('label'               , 'Referrer')
-      ->addValue('name'                , 'membership_referrer')
-      ->execute();
-  }
-
-  private static function createReferrerOfRelationship() {
-    Api4\RelationshipType::create(FALSE)
-      ->addValue('contact_type_a', 'Individual')
-      ->addValue('contact_type_b', 'Individual')
-      ->addValue('label_a_b', 'Referrer of')
-      ->addValue('label_b_a', 'Referrer by')
-      ->addValue('name_a_b', 'Referrer of')
-      ->addValue('name_b_a', 'Referrer by')
-      ->execute();
-  }
-
   private static function createRequiredOptionValues() {
     Api4\OptionValue::create(FALSE)
       ->addValue('is_active', TRUE)
       ->addValue('label', 'Import Error')
       ->addValue('name', 'streetimport_error')
       ->addValue('option_group_id.name', 'activity_type')
-      ->execute();
-  }
-
-  private static function createUTMCustomFields() {
-    Api4\CustomGroup::create(FALSE)
-      ->addValue('extends'    , 'Activity')
-      ->addValue('name'       , 'utm')
-      ->addValue('table_name' , 'civicrm_value_utm')
-      ->addValue('title'      , 'UTM Tracking Information')
-      ->execute();
-
-    Api4\CustomField::create(FALSE)
-      ->addValue('column_name'         , 'utm_content')
-      ->addValue('custom_group_id:name', 'utm')
-      ->addValue('data_type'           , 'String')
-      ->addValue('html_type'           , 'Text')
-      ->addValue('is_required'         , FALSE)
-      ->addValue('label'               , 'Content')
-      ->addValue('name'                , 'utm_content')
-      ->execute();
-
-    Api4\CustomField::create(FALSE)
-      ->addValue('column_name'         , 'utm_campaign')
-      ->addValue('custom_group_id:name', 'utm')
-      ->addValue('data_type'           , 'String')
-      ->addValue('html_type'           , 'Text')
-      ->addValue('is_required'         , FALSE)
-      ->addValue('label'               , 'Campaign')
-      ->addValue('name'                , 'utm_campaign')
-      ->execute();
-
-    Api4\CustomField::create(FALSE)
-      ->addValue('column_name'         , 'utm_medium')
-      ->addValue('custom_group_id:name', 'utm')
-      ->addValue('data_type'           , 'String')
-      ->addValue('html_type'           , 'Text')
-      ->addValue('is_required'         , FALSE)
-      ->addValue('label'               , 'Medium')
-      ->addValue('name'                , 'utm_medium')
-      ->execute();
-
-    Api4\CustomField::create(FALSE)
-      ->addValue('column_name'         , 'utm_source')
-      ->addValue('custom_group_id:name', 'utm')
-      ->addValue('data_type'           , 'String')
-      ->addValue('html_type'           , 'Text')
-      ->addValue('is_required'         , FALSE)
-      ->addValue('label'               , 'Source')
-      ->addValue('name'                , 'utm_source')
-      ->execute();
-
-    Api4\CustomField::create(FALSE)
-      ->addValue('column_name'         , 'utm_term')
-      ->addValue('custom_group_id:name', 'utm')
-      ->addValue('data_type'           , 'String')
-      ->addValue('html_type'           , 'Text')
-      ->addValue('is_required'         , FALSE)
-      ->addValue('label'               , 'Term')
-      ->addValue('name'                , 'utm_term')
-      ->execute();
-
-    Api4\CustomField::create(FALSE)
-      ->addValue('column_name'         , 'utm_id')
-      ->addValue('custom_group_id:name', 'utm')
-      ->addValue('data_type'           , 'String')
-      ->addValue('html_type'           , 'Text')
-      ->addValue('is_required'         , FALSE)
-      ->addValue('label'               , 'Id')
-      ->addValue('name'                , 'utm_id')
       ->execute();
   }
 

--- a/tests/phpunit/api/v3/OSF/DonationTest.php
+++ b/tests/phpunit/api/v3/OSF/DonationTest.php
@@ -22,21 +22,19 @@ class api_v3_OSF_DonationTest extends \PHPUnit\Framework\TestCase implements Hea
    *
    * See: https://docs.civicrm.org/dev/en/latest/testing/phpunit/#civitest
    */
-  public function setUpHeadless()
-  {
+  public function setUpHeadless() {
     return \Civi\Test::headless()
       ->installMe(__DIR__)
       ->install('org.project60.sepa')
       ->install('de.systopia.pspsepa')
       ->install('org.project60.banking')
-      ->apply(TRUE);
+      ->apply();
   }
 
   /**
    * The setup() method is executed before the test is executed (optional).
    */
-  public function setUp(): void
-  {
+  public function setUp(): void {
     $this->contact = reset($this->callAPISuccess('Contact', 'create', [
       'email'        => 'test@example.org',
       'contact_type' => 'Individual',
@@ -57,13 +55,11 @@ class api_v3_OSF_DonationTest extends \PHPUnit\Framework\TestCase implements Hea
    * The tearDown() method is executed after the test was executed (optional)
    * This can be used for cleanup.
    */
-  public function tearDown(): void
-  {
+  public function tearDown(): void {
     parent::tearDown();
   }
 
-  public function testDonationBasic()
-  {
+  public function testDonationBasic() {
     $params = [
       'contact_id' => $this->contact['id'],
       'total_amount' => 100,
@@ -76,8 +72,7 @@ class api_v3_OSF_DonationTest extends \PHPUnit\Framework\TestCase implements Hea
     $this->assertEquals('OSF', $contribution['contribution_source']);
   }
 
-  public function testDonationWithCampaign()
-  {
+  public function testDonationWithCampaign() {
     $campaign = reset($this->callApiSuccess('Campaign', 'create', [
       'title' => "Test Campaign",
       'is_active' => 1,
@@ -95,9 +90,7 @@ class api_v3_OSF_DonationTest extends \PHPUnit\Framework\TestCase implements Hea
     $this->assertEquals(44.44, $contribution['total_amount']);
   }
 
-  public function testDonationWithUtmParams()
-  {
-    $this->setUpCustomGroupUtm();
+  public function testDonationWithUtmParams() {
     $params = [
       'utm_source'   => 'modx',
       'utm_medium'   => 'organic',
@@ -125,8 +118,7 @@ class api_v3_OSF_DonationTest extends \PHPUnit\Framework\TestCase implements Hea
     $this->assertContains('utm_id_value', $activity, 'Activity does not contains utm_id');
   }
 
-  public function testFinancialTypeMemberDues()
-  {
+  public function testFinancialTypeMemberDues() {
     $financial_type_id = 2;
     $this->callApiSuccess('FinancialType', 'create', [
       'id'        => $financial_type_id,
@@ -144,8 +136,7 @@ class api_v3_OSF_DonationTest extends \PHPUnit\Framework\TestCase implements Hea
     $this->assertEquals($financial_type_id, $contribution['financial_type_id']);
   }
 
-  public function testPaymentInstrumentCreditCard()
-  {
+  public function testPaymentInstrumentCreditCard() {
     $json_data = '{"currency":"RON","payment_instrument":"Credit Card","financial_type_id":1,"source":"OSF",
     "total_amount":"60.00","trxn_id":"OSF-TEST-1","psp_result_data":{},"check_permissions":true,"version":3}';
     $params = $this->addTestingContact($json_data);
@@ -159,8 +150,7 @@ class api_v3_OSF_DonationTest extends \PHPUnit\Framework\TestCase implements Hea
     $this->assertEquals($this->getContributionStatusId('Completed'), $contribution['contribution_status_id']);
   }
 
-  public function testPaymentInstrumentPaypal()
-  {
+  public function testPaymentInstrumentPaypal() {
     $this->callApiSuccess('OptionValue', 'create', [
       'option_group_id' => 'payment_instrument',
       'name'            => 'PayPal',
@@ -181,8 +171,7 @@ class api_v3_OSF_DonationTest extends \PHPUnit\Framework\TestCase implements Hea
     $this->assertEquals($this->getContributionStatusId('Completed'), $contribution['contribution_status_id']);
   }
 
-  public function testPaymentInstrumentSofortueberweisung()
-  {
+  public function testPaymentInstrumentSofortueberweisung() {
     $this->callApiSuccess('OptionValue', 'create', [
       'option_group_id' => 'payment_instrument',
       'name'            => 'Sofortüberweisung',
@@ -203,8 +192,7 @@ class api_v3_OSF_DonationTest extends \PHPUnit\Framework\TestCase implements Hea
     $this->assertEquals($this->getContributionStatusId('Completed'), $contribution['contribution_status_id']);
   }
 
-  public function testPaymentInstrumentEPS()
-  {
+  public function testPaymentInstrumentEPS() {
     $this->callApiSuccess('OptionValue', 'create', [
       'option_group_id' => 'payment_instrument',
       'name'            => 'EPS',
@@ -225,8 +213,7 @@ class api_v3_OSF_DonationTest extends \PHPUnit\Framework\TestCase implements Hea
     $this->assertEquals($this->getContributionStatusId('Completed'), $contribution['contribution_status_id']);
   }
 
-  public function testPaymentInstrumentSepa()
-  {
+  public function testPaymentInstrumentSepa() {
     $this->setUpCreditor();
     $json_data = '{"currency":"EUR","payment_instrument":"OOFF","financial_type_id":1,"source":"OSF",
     "sequential":"1","total_amount":"35.00","iban":"AT542011182129643403","check_permissions":true,"version":3}';
@@ -241,8 +228,7 @@ class api_v3_OSF_DonationTest extends \PHPUnit\Framework\TestCase implements Hea
     $this->assertEquals($this->getContributionStatusId('Pending'), $contribution['contribution_status_id']);
   }
 
-  public function testContributionStatusFailed()
-  {
+  public function testContributionStatusFailed() {
     $json_data = '{"failed":true,"cancel_date":"","cancel_reason":"XX01",
     "currency":"GBP","payment_instrument":"Credit Card","financial_type_id":1,"source":"OSF",
     "total_amount":"25.50","trxn_id":"OSF-TEST-99","psp_result_data":{},"check_permissions":true,"version":3}';
@@ -265,8 +251,7 @@ class api_v3_OSF_DonationTest extends \PHPUnit\Framework\TestCase implements Hea
    * @test
    * @dataProvider provideContributionPspResultData
    */
-  public function testPspResultDataIbanAndBIC($json_data, $expected)
-  {
+  public function testPspResultDataIbanAndBIC($json_data, $expected) {
     $this->setUpCreditor();
     $params = $this->addTestingContact($json_data);
     $contribution = reset($this->callApiSuccess('OSF', 'donation', $params)['values']);
@@ -304,8 +289,7 @@ class api_v3_OSF_DonationTest extends \PHPUnit\Framework\TestCase implements Hea
     $this->assertEquals(json_encode($expected), json_encode($actual));
   }
 
-  public function provideContributionPspResultData()
-  {
+  public function provideContributionPspResultData() {
     return [
       [
         'psp_result_data_null' => '{"currency":"EUR","payment_instrument":"EPS","financial_type_id":1,"source":"OSF",
@@ -351,8 +335,7 @@ class api_v3_OSF_DonationTest extends \PHPUnit\Framework\TestCase implements Hea
    *
    * @throws \CiviCRM_API3_Exception
    */
-  public function setUpCreditor()
-  {
+  public function setUpCreditor() {
     $default_creditor_id = (int) CRM_Sepa_Logic_Settings::getSetting('batching_default_creditor');
     if (empty($default_creditor_id)) {
       // create if there isn't
@@ -375,8 +358,7 @@ class api_v3_OSF_DonationTest extends \PHPUnit\Framework\TestCase implements Hea
    * @param $value
    * @return bool|int|string|null
    */
-  public function getContributionStatusId($value)
-  {
+  public function getContributionStatusId($value) {
     return CRM_Core_PseudoConstant::getKey('CRM_Contribute_BAO_Contribution','contribution_status_id', $value);
   }
 
@@ -386,8 +368,7 @@ class api_v3_OSF_DonationTest extends \PHPUnit\Framework\TestCase implements Hea
    * @param $value
    * @return bool|int|string|null
    */
-  public function getPaymentInstrumentId($value)
-  {
+  public function getPaymentInstrumentId($value) {
     return CRM_Core_PseudoConstant::getKey('CRM_Contribute_BAO_Contribution','payment_instrument_id', $value);
   }
 
@@ -405,72 +386,4 @@ class api_v3_OSF_DonationTest extends \PHPUnit\Framework\TestCase implements Hea
     return $params;
   }
 
-  /**
-   * Set Up Custom Group Utm with custom fields
-   *
-   * @throws CRM_Core_Exception
-   */
-  public function setUpCustomGroupUtm()
-  {
-    $custom_group = reset($this->callApiSuccess('CustomGroup', 'create', [
-      'title'     => 'UTM Tracking Information',
-      'extends'   => 'Activity',
-      'name'      => 'utm',
-      'is_active' => 1
-    ])['values']);
-
-    $this->callApiSuccess('CustomField', 'create', [
-      'custom_group_id' => 'utm',
-      'name' => 'utm_source',
-      'label' => 'Source',
-      'data_type' => 'String',
-      'html_type' => 'Text',
-      'is_active' => 1
-    ]);
-
-    $this->callApiSuccess('CustomField', 'create', [
-      'custom_group_id' => 'utm',
-      'name' => 'utm_id',
-      'label' => 'Id',
-      'data_type' => 'String',
-      'html_type' => 'Text',
-      'is_active' => 1
-    ]);
-
-    $this->callApiSuccess('CustomField', 'create', [
-      'custom_group_id' => 'utm',
-      'name' => 'utm_term',
-      'label' => 'Term',
-      'data_type' => 'String',
-      'html_type' => 'Text',
-      'is_active' => 1
-    ]);
-
-    $this->callApiSuccess('CustomField', 'create', [
-      'custom_group_id' => 'utm',
-      'name' => 'utm_medium',
-      'label' => 'Medium',
-      'data_type' => 'String',
-      'html_type' => 'Text',
-      'is_active' => 1
-    ]);
-
-    $this->callApiSuccess('CustomField', 'create', [
-      'custom_group_id' => 'utm',
-      'name' => 'utm_campaign',
-      'label' => 'Campaign',
-      'data_type' => 'String',
-      'html_type' => 'Text',
-      'is_active' => 1
-    ]);
-
-    $this->callApiSuccess('CustomField', 'create', [
-      'custom_group_id' => 'utm',
-      'name' => 'utm_content',
-      'label' => 'Content',
-      'data_type' => 'String',
-      'html_type' => 'Text',
-      'is_active' => 1
-    ]);
-  }
 }

--- a/tests/phpunit/api/v3/OSF/DonationTest.php
+++ b/tests/phpunit/api/v3/OSF/DonationTest.php
@@ -28,7 +28,7 @@ class api_v3_OSF_DonationTest extends \PHPUnit\Framework\TestCase implements Hea
       ->install('org.project60.sepa')
       ->install('de.systopia.pspsepa')
       ->install('org.project60.banking')
-      ->apply();
+      ->apply(TRUE);
   }
 
   /**

--- a/tests/phpunit/api/v3/OSF/GetcontractTest.php
+++ b/tests/phpunit/api/v3/OSF/GetcontractTest.php
@@ -43,6 +43,8 @@ class api_v3_OSF_GetcontractTest extends api_v3_OSF_ContractTestBase {
       'payment_method.type'                  => 'RCUR',
       'source'                               => 'OSF',
       'start_date'                           => $join_date,
+      'debug' => 1,
+      'options' => ['debug' => 1],
     ];
 
     $contract_result = civicrm_api3('Contract', 'create', $create_contract_params);

--- a/tests/phpunit/api/v3/OSF/GetcontractTest.php
+++ b/tests/phpunit/api/v3/OSF/GetcontractTest.php
@@ -26,7 +26,6 @@ class api_v3_OSF_GetcontractTest extends api_v3_OSF_ContractTestBase {
     $create_contract_params = [
       'campaign_id'                          => $campaign['id'],
       'contact_id'                           => $contact['id'],
-      'debug'                                => FALSE,
       'join_date'                            => $join_date,
       'membership_type_id'                   => $membership_type_id,
       'payment_method.adapter'               => 'sepa_mandate',

--- a/tests/phpunit/api/v3/OSF/UpdatecontractTest.php
+++ b/tests/phpunit/api/v3/OSF/UpdatecontractTest.php
@@ -54,7 +54,7 @@ class api_v3_OSF_UpdatecontractTest extends api_v3_OSF_ContractTestBase {
 
     $payment_details = [
       'merchant_account'  => 'Merch',
-      'shopper_reference' => 'ADYEN-123',
+      'shopper_reference' => 'OSF-TOKEN-PRODUCTION-00001-EPS',
     ];
     
     $transaction_details = [
@@ -71,7 +71,7 @@ class api_v3_OSF_UpdatecontractTest extends api_v3_OSF_ContractTestBase {
       'hash'                     => $contact['hash'],
       'membership_type'          => 'Foerderer',
       'payment_details'          => $payment_details,
-      'payment_instrument'       => 'Debit Card',
+      'payment_instrument'       => 'Credit Card',
       'payment_service_provider' => 'adyen',
       'transaction_details'      => $transaction_details,
     ]);
@@ -90,7 +90,7 @@ class api_v3_OSF_UpdatecontractTest extends api_v3_OSF_ContractTestBase {
 
     $recurring_contribution = Api4\ContributionRecur::get(FALSE)
       ->addWhere('id', '=', $recur_contrib_id)
-      ->addSelect('*', 'payment_instrument_id:name')
+      ->addSelect('*')
       ->execute()
       ->first();
 
@@ -100,7 +100,6 @@ class api_v3_OSF_UpdatecontractTest extends api_v3_OSF_ContractTestBase {
     $this->assertEquals(17, $recurring_contribution['cycle_day']);
     $this->assertEquals(3, $recurring_contribution['frequency_interval']);
     $this->assertEquals('month', $recurring_contribution['frequency_unit']);
-    $this->assertEquals('Debit Card', $recurring_contribution['payment_instrument_id:name']);
     $this->assertEquals('17', $rc_start_date->format('d'));
 
   }
@@ -170,7 +169,7 @@ class api_v3_OSF_UpdatecontractTest extends api_v3_OSF_ContractTestBase {
 
     $payment_details = [
       'merchant_account'  => 'Merch',
-      'shopper_reference' => 'ADYEN-123',
+      'shopper_reference' => 'OSF-TOKEN-PRODUCTION-00001-EPS',
     ];
     
     $transaction_details = [
@@ -186,7 +185,7 @@ class api_v3_OSF_UpdatecontractTest extends api_v3_OSF_ContractTestBase {
       'hash'                     => $contact['hash'],
       'membership_type'          => 'Foerderer',
       'payment_details'          => $payment_details,
-      'payment_instrument'       => 'Debit Card',
+      'payment_instrument'       => 'Credit Card',
       'payment_service_provider' => 'adyen',
       'transaction_details'      => $transaction_details,
     ]);
@@ -206,14 +205,13 @@ class api_v3_OSF_UpdatecontractTest extends api_v3_OSF_ContractTestBase {
 
     $recurring_contribution = Api4\ContributionRecur::get(FALSE)
       ->addWhere('id', '=', $recur_contrib_id)
-      ->addSelect('*', 'payment_instrument_id:name')
+      ->addSelect('*')
       ->execute()
       ->first();
 
     $this->assertEquals(20.0, $recurring_contribution['amount']);
     $this->assertEquals(3, $recurring_contribution['frequency_interval']);
     $this->assertEquals('month', $recurring_contribution['frequency_unit']);
-    $this->assertEquals('Debit Card', $recurring_contribution['payment_instrument_id:name']);
 
   }
 


### PR DESCRIPTION
In the `OSF.donation` API, the `trxn_id` parameter actually maps to the `invoice_id` contribution parameter (i.e. the merchant reference).